### PR TITLE
Fixes sorting by issuesNumber bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,10 +37,10 @@ axios.get('/api/data')
             if ( a.openPRsNumber > b.openPRsNumber ){
                 return -1;
             }
-            if ( a.openPRsNumber < b.openPRsNumber ){
+            if ( a.issuesNumber < b.issuesNumber ){
                 return 1;
             }
-            if ( a.openPRsNumber > b.openPRsNumber ){
+            if ( a.issuesNumber > b.issuesNumber ){
                 return -1;
             }
             return 0;


### PR DESCRIPTION
Fixes the sorting by issuesNumber bug. Sorting by `openPRsNumber` was mistakenly done twice [here](https://github.com/RocketChat/GSoC-Contribution-Leaderboard-Node/blob/1d5f44596d8529fbaf64e3bcb479063152b8c42a/src/index.js#L34-L45). This PR fixes that.